### PR TITLE
fix: disable slow tests and add 120s CI timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
       run: cmake --build build
 
     - name: Run tests
-      run: cd build && ctest --output-on-failure
+      run: cd build && ctest --output-on-failure --timeout 120

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,6 +282,8 @@ else()
     endif()
 endif()
 add_test(NAME Phase8PhysicsInformedTest COMMAND Phase8PhysicsInformedTest)
+# Takes 16+ minutes on CI - too slow for regular CI runs
+set_tests_properties(Phase8PhysicsInformedTest PROPERTIES DISABLED true)
 
 # Phase 8 Comprehensive Physics-Informed Neural Networks Test executable
 add_executable(Phase8PhysicsComprehensiveTest tests/test_phase8_physics_comprehensive.cpp)


### PR DESCRIPTION
## Summary
- **Disable Phase8PhysicsInformedTest** — takes 971 seconds (16+ minutes) on CI, making the pipeline 20+ min. Can still be run locally.
- **Add `--timeout 120` to ctest** — kills any test that runs longer than 2 minutes, preventing CI stalls.

### Test timing (before this change):
| Test | Time | Status |
|---|---|---|
| Phase8PhysicsInformedTest | 971s | **NOW DISABLED** |
| ReinforcementLearningBenchmark | 22s | OK |
| TinyMLTests | 20s | OK |
| SimpleAttentionBenchmark | 14s | OK |
| AttentionBenchmark | 11s | OK |
| All others | <8s each | OK |
| **Total (after fix)** | **~90s** | |

## Test plan
- [ ] CI completes in ~2-3 minutes instead of 20+

🤖 Generated with [Claude Code](https://claude.com/claude-code)